### PR TITLE
plus one judgement condition in the convertToReconSpace3D/2D function

### DIFF
--- a/toolboxes/gtplus/workflow/gtPlusISMRMRDReconWorkFlowCartesian.h
+++ b/toolboxes/gtplus/workflow/gtPlusISMRMRDReconWorkFlowCartesian.h
@@ -346,7 +346,7 @@ convertToReconSpace2D(hoNDArray<T>& input_, hoNDArray<T>& output_, bool isKSpace
         output_ = input_;
 
         // if encoded FOV are the same as recon FOV
-        if ( (std::abs(encodingFOV_RO_/2 - reconFOV_RO_)<0.1) && (std::abs(encodingFOV_E1_-reconFOV_E1_)<0.1) )
+        if ( (std::abs(encodingFOV_RO_/2 - reconFOV_RO_)<0.1) && (std::abs(encodingFOV_E1_-reconFOV_E1_)<0.1) && inputE1<reconSizeE1_)
         {
             if ( isKSpace )
             {
@@ -373,7 +373,7 @@ convertToReconSpace2D(hoNDArray<T>& input_, hoNDArray<T>& output_, bool isKSpace
             hoNDArray<T> buffer2D;
 
             // adjust E1
-            if ( encodingE1>E1 && encodingE1>inputE1 )
+            if ( encodingE1>E1 && encodingE1>inputE1 && inputE1<reconSizeE1_)
             {
                 if ( isKSpace )
                 {
@@ -481,7 +481,7 @@ convertToReconSpace3D(hoNDArray<T>& input_, hoNDArray<T>& output_, bool isKSpace
         output_ = input_;
 
         // if encoded FOV are the same as recon FOV
-        if ( (std::abs(encodingFOV_RO_/2 - reconFOV_RO_)<0.1) && (std::abs(encodingFOV_E1_-reconFOV_E1_)<0.1) && (std::abs(encodingFOV_E2_-reconFOV_E2_)<0.1) )
+        if ( (std::abs(encodingFOV_RO_/2 - reconFOV_RO_)<0.1) && (std::abs(encodingFOV_E1_-reconFOV_E1_)<0.1) && (std::abs(encodingFOV_E2_-reconFOV_E2_)<0.1) && E1<reconSizeE1_)
         {
             if ( isKSpace )
             {
@@ -515,7 +515,7 @@ convertToReconSpace3D(hoNDArray<T>& input_, hoNDArray<T>& output_, bool isKSpace
             hoNDArray<T> buffer3D;
 
             // adjust E1
-            if ( encodingE1 >= E1+1 )
+            if ( encodingE1 >= E1+1 && E1<reconSizeE1_ )
             {
                 if ( isKSpace )
                 {


### PR DESCRIPTION
  It seems like a bug is in file" gtplusISMRMRDReconWorkflowCartesian.h ". It occured in the function 'converToReconSpace2D/3D' .

```
     Inside the two functions,   zpadResize2D/3D function is called,  but an error occured if  E1>reconSizeE1, which is often  the 
```

case when phase resolution is 100% as well as  ETL is used 

```
     So, I think  an additional  condition "E1<reconSizeE1" should be added to judge whether to call the  zpadResize2D/3D function.
```
